### PR TITLE
Add type tests, update docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,10 +4,14 @@ A subset of fields from a `package.json` object needed to extract a repo URL.
 For a more fully-featured type, see [`type-fest`](https://github.com/sindresorhus/type-fest/blob/main/source/package-json.d.ts).
 */
 export type PackageJson = {
-	/** The name of the package. */
+	/**
+ 	The name of the package.
+  	*/
 	name: string;
 
-	/** Location for the code repository. */
+	/**
+ 	Location for the code repository.
+  	*/
 	repository?: string | {
 		url: string;
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export type PackageJson = {
 	name: string;
 
 	/**
-	Location for the code repository.
+	The location of the source code repository.
 	*/
 	repository?: string | {
 		url: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,13 +5,13 @@ For a more fully-featured type, see [`type-fest`](https://github.com/sindresorhu
 */
 export type PackageJson = {
 	/**
- 	The name of the package.
-  	*/
+	The name of the package.
+	*/
 	name: string;
 
 	/**
- 	Location for the code repository.
-  	*/
+	Location for the code repository.
+	*/
 	repository?: string | {
 		url: string;
 	};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,20 @@
+/**
+A subset of fields from a `package.json` object needed to extract a repo URL.
+
+For a more fully-featured type, see [`type-fest`](https://github.com/sindresorhus/type-fest/blob/main/source/package-json.d.ts).
+*/
 export type PackageJson = {
+	/** The name of the package. */
 	name: string;
-	homepage?: string;
-	repository?:
-	| string
-	| {
-		type: string;
+
+	/** Location for the code repository. */
+	repository?: string | {
 		url: string;
-		directory?: string;
 	};
 };
 
 /**
-Extracts the repo URL from a package.json object.
+Extracts the repo URL from a `package.json` object.
 
 @example
 ```

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,44 @@
+import {expectError, expectType} from 'tsd';
+import repoUrlFromPackage, {type PackageJson} from './index.js';
+
+declare const packageJson: PackageJson;
+
+expectType<string>(packageJson.name);
+expectType<string | {url: string} | undefined>(packageJson.repository);
+
+const {url, warnings} = repoUrlFromPackage(packageJson);
+
+expectType<string | undefined>(url);
+expectType<string[]>(warnings);
+
+repoUrlFromPackage({
+	name: 'my-package',
+	repository: 'https://github.com/user/repo.git',
+});
+
+repoUrlFromPackage({
+	name: 'my-package',
+	repository: {
+		url: 'https://github.com/user/repo.git',
+	},
+});
+
+repoUrlFromPackage({
+	name: 'my-package',
+	repository: {
+		url: 'https://example.com',
+	},
+});
+
+repoUrlFromPackage({
+	name: 'my-package',
+	repository: {
+		url: 'invalid-url',
+	},
+});
+
+repoUrlFromPackage({
+	name: 'my-package',
+});
+
+expectError(repoUrlFromPackage({}));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && ava && tsc index.d.ts"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -40,7 +40,7 @@
 	},
 	"devDependencies": {
 		"ava": "^6.1.3",
-		"typescript": "^5.5.4",
+		"tsd": "^0.31.1",
 		"xo": "^0.59.2"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,12 @@ console.log(url);
 
 ## API
 
-See the [types](index.d.ts) for now.
+### repoUrlFromPackage(packageJson)
+
+Returns an object with the possible parsed `url` and an array of any `warnings`.
+
+#### packageJson
+
+Type: `object`
+
+A `package.json` object.


### PR DESCRIPTION
Mostly independent from #1, but copies the type changes over and adds extra documentation.

Not sure on the return type documentation in the readme.