### PR TITLE
Drop dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 import githubUrlFromGit from 'github-url-from-git';
-import isUrl from 'is-url-superb';
+
+function isUrl(string) {
+	try {
+		return Boolean(new URL(string));
+	} catch {
+		return false;
+	}
+}
 
 export default function repoUrlFromPackage(packageJson) {
 	if (!packageJson.repository) {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
 		"parse"
 	],
 	"dependencies": {
-		"github-url-from-git": "^1.5.0",
-		"is-url-superb": "^6.1.0"
+		"github-url-from-git": "^1.5.0"
 	},
 	"devDependencies": {
 		"ava": "^6.1.3",


### PR DESCRIPTION
Welcome change? `new URL()` is able to parse http/s URLs, so it doesn't need special behavior (some platforms fail parsing `git+https://` URLs for example, but that's not relevant here)